### PR TITLE
Filter update for 3.5.0.

### DIFF
--- a/PoeFilterParser.NUnit.IntegrationTests/Filters/NeverSink's filter - 5-UBER-STRICT.filter
+++ b/PoeFilterParser.NUnit.IntegrationTests/Filters/NeverSink's filter - 5-UBER-STRICT.filter
@@ -209,6 +209,17 @@
 # [[0100]] OVERRIDE AREA 1 - Override ALL rules here
 #===============================================================================================================
 
+Show # New filter features
+	Prophecy "The Queen's Sacrifice" "Trash to Treasure" "Fated Connections"
+	SetFontSize 45
+	SetTextColor 255 0 0 255             # TEXTCOLOR:	 T0 Item
+	SetBorderColor 255 0 0 255           # BORDERCOLOR:	 T0 Item
+	SetBackgroundColor 255 255 255 255   # BACKGROUND:	 T0 Drop
+	PlayAlertSound 6 300                 # DROPSOUND:	 T0 Drop
+	MinimapIcon 0 Red Star
+	PlayEffect Red
+
+
 #===============================================================================================================
 # [[0200]] 6 LINKS
 #===============================================================================================================

--- a/PoeFilterParser/PoeFilter.g4
+++ b/PoeFilterParser/PoeFilter.g4
@@ -86,6 +86,7 @@ poeMapTier: 'MapTier' compareOpNullable digitsParams;
 poeCustomAlertSound: 'CustomAlertSound' params;
 poeMinimapIcon: 'MinimapIcon' iconParams;
 poePlayEffect: 'PlayEffect' playEffectParams;
+poeProphecy: 'Prophecy' params;
 
 statement:  poeClass
          |  poeFontSize 
@@ -116,7 +117,8 @@ statement:  poeClass
 		 |  poeMapTier
 		 |  poeCustomAlertSound
 		 |  poeMinimapIcon
-		 |  poePlayEffect;
+		 |  poePlayEffect
+		 |  poeProphecy;
 		 
 
 block: visibility statement*?;


### PR DESCRIPTION
Added support for `Prophecy` keyword.
Added a few high value Prophecies to the start of the filter to test the new keyword.